### PR TITLE
Update sensor.py

### DIFF
--- a/custom_components/sihas/sensor.py
+++ b/custom_components/sihas/sensor.py
@@ -129,14 +129,14 @@ PMM_GENERIC_SENSOR_DEFINE: Final = {
     ),
     PMM_KEY_THIS_MONTH_ENERGY: PmmConfig(
         nuom=ENERGY_WATT_HOUR,
-        value_handler=lambda r: r[10] * 10,
+        value_handler=lambda r: r[10] * 10 + r[16],
         device_class=SensorDeviceClass.ENERGY,
         state_class=STATE_CLASS_TOTAL,
         sub_id=PMM_KEY_THIS_MONTH_ENERGY,
     ),
     PMM_KEY_THIS_DAY_ENERGY: PmmConfig(
         nuom=ENERGY_WATT_HOUR,
-        value_handler=lambda r: r[8] * 10,
+        value_handler=lambda r: r[8] * 10 + r[16],
         device_class=SensorDeviceClass.ENERGY,
         state_class=STATE_CLASS_TOTAL,
         sub_id=PMM_KEY_THIS_DAY_ENERGY,


### PR DESCRIPTION
당일 사용량과 당월 사용량 센서의 인터벌이 20분으로 너무 긴 듯하여 해당 값에 지난 20분간의 실시간 데이터를 더해서 센서값을 표시하도록 수정했습니다.