### PR TITLE
Update sensor.py

### DIFF
--- a/custom_components/sihas/sensor.py
+++ b/custom_components/sihas/sensor.py
@@ -174,7 +174,7 @@ PMM_GENERIC_SENSOR_DEFINE: Final = {
     ),
     PMM_KEY_CURRENT: PmmConfig(
         nuom=ELECTRIC_CURRENT_AMPERE,
-        value_handler=lambda r: r[1] / 10,
+        value_handler=lambda r: r[1] / 100,
         device_class=SensorDeviceClass.CURRENT,
         state_class=STATE_CLASS_MEASUREMENT,
         sub_id=PMM_KEY_CURRENT,


### PR DESCRIPTION
PMM ELECTRIC_CURRENT_AMPERE의 소수점 처리 버그가 있어서 수정했습니다. 

## 수정 코드
```
PMM_KEY_CURRENT: PmmConfig(
    nuom=ELECTRIC_CURRENT_AMPERE,
    value_handler=lambda r: r[1] / 100,  # 여기 수정 (기존 값 10)
    device_class=SensorDeviceClass.CURRENT,
    state_class=STATE_CLASS_MEASUREMENT,
    sub_id=PMM_KEY_CURRENT,
)
```

## 테스트
### 앱상 표시 (정상)데이터
<img src="https://github.com/cmsong-shina/sihas-canary/assets/37164539/164239f9-c6a5-4b8a-ae40-5c5497dd7c40" width="40%" height="40%"/>

### 기존 (수정 전)
<img src="https://github.com/cmsong-shina/sihas-canary/assets/37164539/ef8bd13d-0524-4f8a-ad79-57b208defe72" width="40%" height="40%"/>

### 버그 수정 후
<img src="https://github.com/cmsong-shina/sihas-canary/assets/37164539/c828559a-64b1-4660-b84c-420ef2531559" width="40%" height="40%"/>
